### PR TITLE
Option to use MessagePack with Http

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@
 
 # declaration
 variables:
-  VERSION: "1.0.4"
+  VERSION: "1.0.5"
   BASE_DOC_DOCKER_IMAGE: abitech/nextapi-docs
 
 stages:
@@ -31,7 +31,7 @@ nugetize-testing:
   variables:
     projectFolder: src/base/NextApi.Testing
     projectName: NextApi.Testing
-    NEXTAPI_CLIENT_VERSION: "1.0.1"
+    NEXTAPI_CLIENT_VERSION: "1.0.5"
     NEXTAPI_EFCORE_VERSION: "1.0.1"
 
 nugetize-common:
@@ -45,7 +45,7 @@ nugetize-common-server:
   variables:
     projectFolder: src/base/NextApi.Server.Common
     projectName: NextApi.Server.Common
-    NEXTAPI_COMMON_VERSION: "1.0.3"
+    NEXTAPI_COMMON_VERSION: "1.0.5"
 
 nugetize-common-uploadqueue:
   <<: *nugetize
@@ -59,7 +59,7 @@ nugetize-client:
   variables:
     projectFolder: src/client/NextApi.Client
     projectName: NextApi.Client
-    NEXTAPI_COMMON_VERSION: "1.0.1"
+    NEXTAPI_COMMON_VERSION: "1.0.5"
 
 nugetize-client-uploadqueue:
   <<: *nugetize
@@ -88,7 +88,7 @@ nugetize-server:
   variables:
     projectFolder: src/server/NextApi.Server
     projectName: NextApi.Server
-    NEXTAPI_SERVER_COMMON_VERSION: "1.0.3"
+    NEXTAPI_SERVER_COMMON_VERSION: "1.0.5"
 
 nugetize-server-efcore:
   <<: *nugetize

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@
 
 # declaration
 variables:
-  VERSION: "1.0.5"
+  VERSION: "1.1.0"
   BASE_DOC_DOCKER_IMAGE: abitech/nextapi-docs
 
 stages:
@@ -31,7 +31,7 @@ nugetize-testing:
   variables:
     projectFolder: src/base/NextApi.Testing
     projectName: NextApi.Testing
-    NEXTAPI_CLIENT_VERSION: "1.0.5"
+    NEXTAPI_CLIENT_VERSION: "1.1.0"
     NEXTAPI_EFCORE_VERSION: "1.0.1"
 
 nugetize-common:
@@ -45,7 +45,7 @@ nugetize-common-server:
   variables:
     projectFolder: src/base/NextApi.Server.Common
     projectName: NextApi.Server.Common
-    NEXTAPI_COMMON_VERSION: "1.0.5"
+    NEXTAPI_COMMON_VERSION: "1.1.0"
 
 nugetize-common-uploadqueue:
   <<: *nugetize
@@ -59,7 +59,7 @@ nugetize-client:
   variables:
     projectFolder: src/client/NextApi.Client
     projectName: NextApi.Client
-    NEXTAPI_COMMON_VERSION: "1.0.5"
+    NEXTAPI_COMMON_VERSION: "1.1.0"
 
 nugetize-client-uploadqueue:
   <<: *nugetize
@@ -88,7 +88,7 @@ nugetize-server:
   variables:
     projectFolder: src/server/NextApi.Server
     projectName: NextApi.Server
-    NEXTAPI_SERVER_COMMON_VERSION: "1.0.5"
+    NEXTAPI_SERVER_COMMON_VERSION: "1.1.0"
 
 nugetize-server-efcore:
   <<: *nugetize

--- a/src/base/NextApi.Common/Serialization/SerializationType.cs
+++ b/src/base/NextApi.Common/Serialization/SerializationType.cs
@@ -1,0 +1,17 @@
+﻿namespace NextApi.Common.Serialization
+{
+    /// <summary>
+    /// Enum that represents serialization types
+    /// </summary>
+    public enum SerializationType
+    {
+        /// <summary>
+        /// Json
+        /// </summary>
+        Json,
+        /// <summary>
+        /// MessagePack
+        /// </summary>
+        MessagePack
+    }
+}

--- a/src/base/NextApi.Testing/INextApiApplication.cs
+++ b/src/base/NextApi.Testing/INextApiApplication.cs
@@ -1,6 +1,7 @@
 using System;
 using NextApi.Client;
 using NextApi.Common.Abstractions;
+using NextApi.Common.Serialization;
 using Xunit.Abstractions;
 
 namespace NextApi.Testing
@@ -28,17 +29,19 @@ namespace NextApi.Testing
         /// </summary>
         /// <param name="token">Fake token (if required)</param>
         /// <param name="transport">Transport type</param>
+        /// <param name="httpSerializationType">Serialization type for http transport type</param>
         /// <returns>Instance of NextApi client</returns>
-        TClient ResolveClient(string token = null, NextApiTransport transport = NextApiTransport.Http);
+        TClient ResolveClient(string token = null, NextApiTransport transport = NextApiTransport.Http, SerializationType httpSerializationType = SerializationType.Json);
 
         /// <summary>
         /// Resolve client-side NextApi service
         /// </summary>
         /// <param name="token">Fake token (if required)</param>
         /// <param name="transport">Transport type</param>
+        /// <param name="httpSerializationType">Serialization type for http transport type</param>
         /// <typeparam name="TService">Service type</typeparam>
         /// <returns></returns>
-        TService ResolveService<TService>(string token = null, NextApiTransport transport = NextApiTransport.Http)
+        TService ResolveService<TService>(string token = null, NextApiTransport transport = NextApiTransport.Http, SerializationType httpSerializationType = SerializationType.Json)
             where TService : INextApiService;
 
         /// <summary>

--- a/src/client/NextApi.Client/NextApiClient.cs
+++ b/src/client/NextApi.Client/NextApiClient.cs
@@ -291,14 +291,8 @@ namespace NextApi.Client
 
             // check that response can processed as json
             var mediaType = response.Content.Headers.ContentType.MediaType;
-            if (!mediaType.Contains("application/json") && !mediaType.Contains("application/octet-stream"))
+            if (!mediaType.Contains("application/json") && typeof(T) == typeof(NextApiFileResponse))
             {
-                if (typeof(T) != typeof(NextApiFileResponse))
-                    throw new NextApiException(
-                        NextApiErrorCode.IncorrectRequest,
-                        "Please specify correct return type for this request. Use NextApiFileResponse."
-                    );
-
                 try
                 {
                     return await NextApiClientUtils.ProcessNextApiFileResponse(response) as dynamic;

--- a/src/server/NextApi.Server/Service/NextApiServiceHelper.cs
+++ b/src/server/NextApi.Server/Service/NextApiServiceHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Reflection;
@@ -205,6 +206,20 @@ namespace NextApi.Server.Service
             response.ContentType = "application/json";
             var encoded = JsonConvert.SerializeObject(data, SerializationUtils.GetJsonConfig());
             await response.WriteAsync(encoded);
+        }
+
+        /// <summary>
+        /// Wrapper for sending byte array to client
+        /// </summary>
+        /// <param name="response"></param>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        public static async Task SendByteArray(this HttpResponse response, byte[] data)
+        {
+            response.StatusCode = 200;
+            response.ContentType = "application/octet-stream";
+            using var memoryStream = new MemoryStream(data);
+            await memoryStream.CopyToAsync(response.Body);
         }
 
         /// <summary>

--- a/test/NextApi.Server.Tests/Base/DataHelpers.cs
+++ b/test/NextApi.Server.Tests/Base/DataHelpers.cs
@@ -32,7 +32,8 @@ namespace NextApi.Server.Tests.Base
                     City = city,
                     Role = role,
                     Birthday = initialDate.AddYears(id),
-                    ExtraInfo = id % 2 == 0 ? "even" : "odd"
+                    ExtraInfo = id % 2 == 0 ? "even" : "odd",
+                    DecimalProperty = id
                 };
                 await db.Context.Users.AddAsync(user);
             }

--- a/test/NextApi.Server.Tests/Base/TestApplication.cs
+++ b/test/NextApi.Server.Tests/Base/TestApplication.cs
@@ -1,6 +1,7 @@
 using NextApi.TestClient;
 using NextApi.TestServer;
 using NextApi.Client;
+using NextApi.Common.Serialization;
 using NextApi.Testing;
 using NextApi.Testing.Security;
 
@@ -19,8 +20,11 @@ namespace NextApi.Server.Tests.Base
                 .Add<ITestTreeItemService, TestTreeItemService>()
                 .Add<ITestUploadQueueService, TestUploadQueueService>();
 
-        protected override INextApiClient ClientBuilder(TestTokenProvider tokenProvider, NextApiTransport transport) =>
-            new NextApiClient("ws://localhost/nextapi", tokenProvider, transport);
+        protected override INextApiClient ClientBuilder(TestTokenProvider tokenProvider, NextApiTransport transport, SerializationType httpSerializationType = SerializationType.Json) =>
+            new NextApiClient("ws://localhost/nextapi", tokenProvider, transport)
+            {
+                HttpSerializationType = httpSerializationType
+            };
 
         public TestApplication()
         {

--- a/test/NextApi.Server.Tests/NextApiEntityServiceTests.cs
+++ b/test/NextApi.Server.Tests/NextApiEntityServiceTests.cs
@@ -281,7 +281,7 @@ namespace NextApi.Server.Tests
             
             // TODO Same request fails with Json serialization
             // decimal is deserialized as double at server side
-            var userServiceJson = ResolveUserService(transport);
+            var userServiceJson = ResolveUserService(NextApiTransport.Http);
             await Assert.ThrowsAnyAsync<Exception>(async () => await userServiceJson.GetPaged(paged));
         }
         

--- a/test/NextApi.Server.Tests/NextApiEntityServiceTests.cs
+++ b/test/NextApi.Server.Tests/NextApiEntityServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -13,6 +14,7 @@ using NextApi.Common.Abstractions.DAL;
 using NextApi.Common.Filtering;
 using NextApi.Common.Ordering;
 using NextApi.Common.Paged;
+using NextApi.Common.Serialization;
 using NextApi.Common.Tree;
 using NextApi.Server.Tests.Base;
 using NextApi.Testing;
@@ -76,8 +78,10 @@ namespace NextApi.Server.Tests
             }
         }
 
-        private ITestUserService ResolveUserService(NextApiTransport transport = NextApiTransport.SignalR) =>
-            App.ResolveService<ITestUserService>(null, transport);
+        private ITestUserService ResolveUserService(
+            NextApiTransport transport = NextApiTransport.SignalR,
+            SerializationType httpSerializationType = SerializationType.Json)
+            => App.ResolveService<ITestUserService>(null, transport, httpSerializationType);
 
         [Theory]
         [InlineData(NextApiTransport.Http)]
@@ -256,6 +260,29 @@ namespace NextApi.Server.Tests
 
             Assert.True(data.TotalItems == 3);
             Assert.True(data.Items.All(e => e.Id == 5 || e.Id == 10 || e.Id == 14));
+        }
+
+        [Theory]
+        [InlineData(NextApiTransport.Http)]
+        [InlineData(NextApiTransport.SignalR)]
+        public async Task TestDecimalFilter(NextApiTransport transport)
+        {
+            await App.GenerateUsers(10);
+            var paged = new PagedRequest
+            {
+                Filter = new FilterBuilder()
+                    .LessThan<decimal>(nameof(TestUserDTO.DecimalProperty), 6)
+                    .Build()
+            };
+
+            var userServiceMp = ResolveUserService(transport, SerializationType.MessagePack);
+            var data = await userServiceMp.GetPaged(paged);
+            Assert.True(data.TotalItems == 5);
+            
+            // TODO Same request fails with Json serialization
+            // decimal is deserialized as double at server side
+            var userServiceJson = ResolveUserService(transport);
+            await Assert.ThrowsAnyAsync<Exception>(async () => await userServiceJson.GetPaged(paged));
         }
         
         [Theory]

--- a/test/test-server/NextApi.TestServer/DTO/TestUserDTO.cs
+++ b/test/test-server/NextApi.TestServer/DTO/TestUserDTO.cs
@@ -17,5 +17,6 @@ namespace NextApi.TestServer.DTO
         public virtual TestCityDTO City { get; set; }
         public virtual TestRoleDTO Role { get; set; }
         public string UnknownProperty { get; set; }
+        public decimal DecimalProperty { get; set; }
     }
 }

--- a/test/test-server/NextApi.TestServer/Model/TestUser.cs
+++ b/test/test-server/NextApi.TestServer/Model/TestUser.cs
@@ -19,5 +19,6 @@ namespace NextApi.TestServer.Model
         public string ExtraInfo { get; set; }
         public virtual TestCity City { get; set; }
         public virtual TestRole Role { get; set; }
+        public decimal DecimalProperty { get; set; }
     }
 }


### PR DESCRIPTION
Added the option to use MessagePack with Http transport type.
Args and response are serialized with MessagePack.

The need to use this serialization type arose when we bumped into the issue of incorrect deserialization of some types when using FilterBuilder. This issue is still open and could possibly occur in other places.