### PR TITLE
Throw exceptions in MessagePack serialization for http

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@
 
 # declaration
 variables:
-  VERSION: "1.1.0"
+  VERSION: "1.1.1"
   BASE_DOC_DOCKER_IMAGE: abitech/nextapi-docs
 
 stages:

--- a/src/client/NextApi.Client/NextApiClient.cs
+++ b/src/client/NextApi.Client/NextApiClient.cs
@@ -319,8 +319,10 @@ namespace NextApi.Client
                 case SerializationType.MessagePack:
                 {
                     var resultByteArray = await response.Content.ReadAsByteArrayAsync();
-                    var result = MessagePackSerializer.Typeless.Deserialize(resultByteArray);
-                    return (T) ((NextApiResponse) result).Data;
+                    var result = (NextApiResponse) MessagePackSerializer.Typeless.Deserialize(resultByteArray);
+                    if (!result.Success)
+                        throw NextApiClientUtils.NextApiException(result.Error);
+                    return (T) result.Data;
                 }
                 default:
                     throw new Exception($"Unsupported serialization type {HttpSerializationType}");

--- a/test/NextApi.Server.Tests/NextApiBasicTests.cs
+++ b/test/NextApi.Server.Tests/NextApiBasicTests.cs
@@ -9,6 +9,7 @@ using DeepEqual.Syntax;
 using NextApi.Client;
 using NextApi.Common;
 using NextApi.Common.Filtering;
+using NextApi.Common.Serialization;
 using NextApi.Server.Tests.Base;
 using NextApi.Testing;
 using Xunit;
@@ -61,14 +62,15 @@ namespace NextApi.Server.Tests
         }
 
         [Theory]
-        [InlineData(NextApiTransport.Http)]
-        [InlineData(NextApiTransport.SignalR)]
-        public async Task ExceptionTest(NextApiTransport transport)
+        [InlineData(NextApiTransport.Http, SerializationType.Json)]
+        [InlineData(NextApiTransport.Http, SerializationType.MessagePack)]
+        [InlineData(NextApiTransport.SignalR, SerializationType.MessagePack)]
+        public async Task ExceptionTest(NextApiTransport transport, SerializationType serType)
         {
             Exception ex = null;
             try
             {
-                await ResolveTestService(transport).ExceptionTest();
+                await ResolveTestService(transport, serType).ExceptionTest();
             }
             catch (Exception e)
             {
@@ -88,8 +90,9 @@ namespace NextApi.Server.Tests
             Assert.True(true);
         }
 
-        private ITestService ResolveTestService(NextApiTransport transport = NextApiTransport.Http) =>
-            App.ResolveService<ITestService>(null, transport);
+        private ITestService ResolveTestService(NextApiTransport transport = NextApiTransport.Http,
+            SerializationType serType = SerializationType.Json) =>
+            App.ResolveService<ITestService>(null, transport, serType);
 
         [Theory]
         [InlineData(NextApiTransport.Http)]


### PR DESCRIPTION
Throwing exceptions in MessagePack for http was forgotten about. Sorry)