### PR TITLE
Little performance improvements

### DIFF
--- a/src/server/NextApi.Server/Base/CommandArgsExtractors.cs
+++ b/src/server/NextApi.Server/Base/CommandArgsExtractors.cs
@@ -1,0 +1,19 @@
+﻿using NextApi.Common.Serialization;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Factory class for creating <see cref="ICommandArgsExtractor"/> for specific <see cref="SerializationType"/>.
+    /// </summary>
+    internal static class CommandArgsExtractors
+    {
+        public static ICommandArgsExtractor Create(SerializationType serializationType)
+        {
+            return serializationType switch
+            {
+                SerializationType.MessagePack => new MessagePackCommandArgsExtractor(),
+                _ => new JsonCommandArgsExtractor()
+            };
+        }
+    }
+}

--- a/src/server/NextApi.Server/Base/CommandResultWriters.cs
+++ b/src/server/NextApi.Server/Base/CommandResultWriters.cs
@@ -1,0 +1,26 @@
+﻿using NextApi.Common;
+using NextApi.Common.Serialization;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Factory class for creating <see cref="ICommandResultWriter"/> for <see cref="INextApiResponse"/> and <see cref="SerializationType"/>.
+    /// </summary>
+    internal static class CommandResultWriters
+    {
+        public static ICommandResultWriter Create(INextApiResponse response, SerializationType serializationType)
+        {
+            if (response is NextApiFileResponse)
+            {
+                return new FileCommandResultWriter();
+            }
+
+            return serializationType switch
+            {
+                SerializationType.MessagePack => new MessagePackCommandResultWriter(),
+
+                _ => new JsonCommandResultWriter()
+            };
+        }
+    }
+}

--- a/src/server/NextApi.Server/Base/FileCommandResultWriter.cs
+++ b/src/server/NextApi.Server/Base/FileCommandResultWriter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using NextApi.Common;
+using NextApi.Server.Service;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Writes <see cref="NextApiFileResponse"/> to <see cref="HttpResponse"/>.
+    /// </summary>
+    internal class FileCommandResultWriter : ICommandResultWriter
+    {
+        /// <inheritdoc/>
+        /// <exception cref="ArgumentException"> Thrown when <paramref name="commandResult"/> is not <see cref="NextApiFileResponse"/></exception>
+        public async Task Write(HttpResponse httpResponse, INextApiResponse commandResult)
+        {
+            if (commandResult is NextApiFileResponse fileResponse)
+            {
+                await httpResponse.SendNextApiFileResponse(fileResponse);
+            }
+
+            throw new ArgumentException($"Result must be of type {typeof(NextApiFileResponse)}", nameof(commandResult));
+        }
+    }
+}

--- a/src/server/NextApi.Server/Base/ICommandArgsExtractor.cs
+++ b/src/server/NextApi.Server/Base/ICommandArgsExtractor.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using NextApi.Common;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Interface is a contract for extracing NextApi command arguments from <see cref="IFormCollection"/>.
+    /// </summary>
+    internal interface ICommandArgsExtractor
+    {
+        /// <summary>
+        /// Extracts NextApi command arguments from form.
+        /// </summary>
+        /// <param name="form"> Http forms collection. </param>
+        /// <returns> Array of NextApi command arguments. </returns>
+        Task<INextApiArgument[]> Extract(IFormCollection form);
+    }
+}

--- a/src/server/NextApi.Server/Base/ICommandResultWriter.cs
+++ b/src/server/NextApi.Server/Base/ICommandResultWriter.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using NextApi.Common;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Interface is contract for writing NextApi responses to <see cref="HttpResponse"/>.
+    /// </summary>
+    internal interface ICommandResultWriter
+    {
+        /// <summary>
+        /// Writes NextApi response to HttpResponse.
+        /// </summary>
+        /// <param name="httpResponse"> Http response </param>
+        /// <param name="commandResult"> NextApi response to write </param>
+        /// <returns></returns>
+        Task Write(HttpResponse httpResponse, INextApiResponse commandResult);
+    }
+}

--- a/src/server/NextApi.Server/Base/JsonCommandArgsExtractor.cs
+++ b/src/server/NextApi.Server/Base/JsonCommandArgsExtractor.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using NextApi.Common;
+using NextApi.Common.Serialization;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Extracts NextApi command arguments using Json serializer.
+    /// </summary>
+    internal class JsonCommandArgsExtractor : ICommandArgsExtractor
+    {
+        private static readonly Task<INextApiArgument[]> CachedNull = Task.FromResult(null as INextApiArgument[]);
+
+        /// <inheritdoc/>
+        public Task<INextApiArgument[]> Extract(IFormCollection form)
+        {
+            var argsString = form["Args"].FirstOrDefault();
+
+            if (string.IsNullOrEmpty(argsString))
+            {
+                return CachedNull;
+            }
+
+            return Task.FromResult(JsonConvert
+                .DeserializeObject<IEnumerable<NextApiJsonArgument>>(argsString, SerializationUtils.GetJsonConfig())
+                .Cast<INextApiArgument>()
+                .ToArray());
+        }
+    }
+}

--- a/src/server/NextApi.Server/Base/JsonCommandResultWriter.cs
+++ b/src/server/NextApi.Server/Base/JsonCommandResultWriter.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using NextApi.Common;
+using NextApi.Server.Service;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Writes <see cref="INextApiResponse"/> to <see cref="HttpResponse"/> as json.
+    /// </summary>
+    internal class JsonCommandResultWriter : ICommandResultWriter
+    {
+        /// <inheritdoc/>
+        public async Task Write(HttpResponse httpResponse, INextApiResponse commandResult)
+        {
+            await httpResponse.SendJson(commandResult);
+        }
+    }
+}

--- a/src/server/NextApi.Server/Base/MessagePackCommandArgsExtractor.cs
+++ b/src/server/NextApi.Server/Base/MessagePackCommandArgsExtractor.cs
@@ -1,0 +1,25 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using MessagePack;
+using Microsoft.AspNetCore.Http;
+using NextApi.Common;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Extracts NextApi command arguments using MessagePack serializer.
+    /// </summary>
+    internal class MessagePackCommandArgsExtractor : ICommandArgsExtractor
+    {
+        /// <inheritdoc/>
+        public async Task<INextApiArgument[]> Extract(IFormCollection form)
+        {
+            var argsFile = form.Files["Args"];
+
+            using var memoryStream = new MemoryStream();
+            await argsFile.CopyToAsync(memoryStream);
+
+            return MessagePackSerializer.Typeless.Deserialize(memoryStream.ToArray()) as INextApiArgument[];
+        }
+    }
+}

--- a/src/server/NextApi.Server/Base/MessagePackCommandResultWriter.cs
+++ b/src/server/NextApi.Server/Base/MessagePackCommandResultWriter.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using MessagePack;
+using Microsoft.AspNetCore.Http;
+using NextApi.Common;
+using NextApi.Server.Service;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Writes NextApi response to HttpResponse as MessagePack encoded byte array.
+    /// </summary>
+    internal class MessagePackCommandResultWriter : ICommandResultWriter
+    {
+        /// <inheritdoc/>
+        public async Task Write(HttpResponse httpResponse, INextApiResponse commandResult)
+        {
+            await httpResponse.SendByteArray(MessagePackSerializer.Serialize(commandResult));
+        }
+    }
+}

--- a/src/server/NextApi.Server/Base/NextApiUtils.cs
+++ b/src/server/NextApi.Server/Base/NextApiUtils.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Globalization;
 using System.Linq;
 
 namespace NextApi.Server.Base
@@ -14,7 +15,7 @@ namespace NextApi.Server.Base
             {
                 null => throw new ArgumentNullException(nameof(input)),
                 "" => throw new ArgumentException($@"{nameof(input)} cannot be empty", nameof(input)),
-                _ => (input.First().ToString().ToUpper() + input.Substring(1))
+                _ => char.ToUpper(input[0], CultureInfo.InvariantCulture) + input.Substring(1)
             };
         }
 

--- a/src/server/NextApi.Server/Security/DisabledNextApiPermissionProvider.cs
+++ b/src/server/NextApi.Server/Security/DisabledNextApiPermissionProvider.cs
@@ -1,4 +1,4 @@
-using System.Security.Claims;
+﻿using System.Security.Claims;
 using System.Threading.Tasks;
 using NextApi.Common.Abstractions.Security;
 
@@ -9,15 +9,15 @@ namespace NextApi.Server.Security
     /// </summary>
     public class DisabledNextApiPermissionProvider : INextApiPermissionProvider
     {
+        private static readonly Task<bool> CachedTrue = Task.FromResult(true);
+
         /// <inheritdoc />
-#pragma warning disable 1998
-        public async Task<bool> HasPermission(ClaimsPrincipal userInfo, object permission)
-#pragma warning restore 1998
+        public Task<bool> HasPermission(ClaimsPrincipal userInfo, object permission)
         {
-            return true;
+            return CachedTrue;
         }
 
         /// <inheritdoc />
-        public string[] SupportedPermissions { get; } = {""};
+        public string[] SupportedPermissions { get; } = { "" };
     }
 }


### PR DESCRIPTION
Here is benchmark of FirstCharToUpper improvement.

```csharp
        [Params("shortString", "1itStartsWithNumber", ".itStartsWithSymbol")]
        public string input;

        [Benchmark]
        public void OldFirstCharToUpper()
        {
            _ = input switch
            {
                null => throw new ArgumentNullException(nameof(input)),
                "" => throw new ArgumentException($@"{nameof(input)} cannot be empty", nameof(input)),
                _ => (input.First().ToString().ToUpper() + input.Substring(1))
            };
        }

        [Benchmark]
        public void NewFirstCharToUpper()
        {
            _ = input switch
            {
                null => throw new ArgumentNullException(nameof(input)),
                "" => throw new ArgumentException($"{nameof(input)} cannot be empty", nameof(input)),
                _ => char.ToUpper(input[0], CultureInfo.InvariantCulture) + input.Substring(1)
            };
        }

        [Benchmark]
        public void NewFirstCharToUpper_First_Instead_of_Index()
        {
            _ = input switch
            {
                null => throw new ArgumentNullException(nameof(input)),
                "" => throw new ArgumentException($"{nameof(input)} cannot be empty", nameof(input)),
                _ => char.ToUpper(input.First(), CultureInfo.InvariantCulture) + input.Substring(1)
            };
        }
```


``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19042.985 (20H2/October2020Update)
Intel Core i5-7400 CPU 3.00GHz (Kaby Lake), 1 CPU, 4 logical and 4 physical cores
.NET SDK=5.0.300
  [Host]     : .NET 5.0.6 (5.0.621.22011), X64 RyuJIT
  DefaultJob : .NET 5.0.6 (5.0.621.22011), X64 RyuJIT


```
|                                     Method |               input |     Mean |    Error |   StdDev |
|------------------------------------------- |-------------------- |---------:|---------:|---------:|
|                        **OldFirstCharToUpper** | **.itStartsWithSymbol** | **78.09 ns** | **1.522 ns** | **1.423 ns** |
|                        NewFirstCharToUpper | .itStartsWithSymbol | 39.39 ns | 0.422 ns | 0.374 ns |
| NewFirstCharToUpper_First_Instead_of_Index | .itStartsWithSymbol | 68.33 ns | 0.525 ns | 0.466 ns |
|                        **OldFirstCharToUpper** | **1itStartsWithNumber** | **77.33 ns** | **0.598 ns** | **0.559 ns** |
|                        NewFirstCharToUpper | 1itStartsWithNumber | 39.38 ns | 0.134 ns | 0.112 ns |
| NewFirstCharToUpper_First_Instead_of_Index | 1itStartsWithNumber | 69.24 ns | 0.487 ns | 0.432 ns |
|                        **OldFirstCharToUpper** |         **shortString** | **89.85 ns** | **1.403 ns** | **1.313 ns** |
|                        NewFirstCharToUpper |         shortString | 38.43 ns | 0.760 ns | 1.138 ns |
| NewFirstCharToUpper_First_Instead_of_Index |         shortString | 68.09 ns | 1.345 ns | 2.248 ns |


And for netcore3.1

``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19042.985 (20H2/October2020Update)
Intel Core i5-7400 CPU 3.00GHz (Kaby Lake), 1 CPU, 4 logical and 4 physical cores
.NET SDK=5.0.300
  [Host]     : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT
  DefaultJob : .NET Core 3.1.15 (CoreCLR 4.700.21.21202, CoreFX 4.700.21.21402), X64 RyuJIT


```
|                                     Method |               input |     Mean |    Error |   StdDev |
|------------------------------------------- |-------------------- |---------:|---------:|---------:|
|                        **OldFirstCharToUpper** | **.itStartsWithSymbol** | **81.35 ns** | **0.359 ns** | **0.336 ns** |
|                        NewFirstCharToUpper | .itStartsWithSymbol | 43.65 ns | 0.204 ns | 0.191 ns |
| NewFirstCharToUpper_First_Instead_of_Index | .itStartsWithSymbol | 74.83 ns | 0.414 ns | 0.387 ns |
|                        **OldFirstCharToUpper** | **1itStartsWithNumber** | **84.76 ns** | **1.725 ns** | **2.736 ns** |
|                        NewFirstCharToUpper | 1itStartsWithNumber | 45.48 ns | 0.934 ns | 1.453 ns |
| NewFirstCharToUpper_First_Instead_of_Index | 1itStartsWithNumber | 71.30 ns | 0.639 ns | 0.598 ns |
|                        **OldFirstCharToUpper** |         **shortString** | **95.23 ns** | **1.334 ns** | **1.248 ns** |
|                        NewFirstCharToUpper |         shortString | 41.66 ns | 0.667 ns | 0.557 ns |
| NewFirstCharToUpper_First_Instead_of_Index |         shortString | 69.55 ns | 0.388 ns | 0.344 ns |
