### PR TITLE
Refactored NextApi.Server/Base/NextApiHttp

### DIFF
--- a/src/server/NextApi.Server/Base/CommandArgsExtractors.cs
+++ b/src/server/NextApi.Server/Base/CommandArgsExtractors.cs
@@ -1,0 +1,19 @@
+﻿using NextApi.Common.Serialization;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Factory class for creating <see cref="ICommandArgsExtractor"/> for specific <see cref="SerializationType"/>.
+    /// </summary>
+    internal static class CommandArgsExtractors
+    {
+        public static ICommandArgsExtractor Create(SerializationType serializationType)
+        {
+            return serializationType switch
+            {
+                SerializationType.MessagePack => new MessagePackCommandArgsExtractor(),
+                _ => new JsonCommandArgsExtractor()
+            };
+        }
+    }
+}

--- a/src/server/NextApi.Server/Base/CommandResultWriters.cs
+++ b/src/server/NextApi.Server/Base/CommandResultWriters.cs
@@ -1,0 +1,26 @@
+﻿using NextApi.Common;
+using NextApi.Common.Serialization;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Factory class for creating <see cref="ICommandResultWriter"/> for <see cref="INextApiResponse"/> and <see cref="SerializationType"/>.
+    /// </summary>
+    internal static class CommandResultWriters
+    {
+        public static ICommandResultWriter Create(INextApiResponse response, SerializationType serializationType)
+        {
+            if (response is NextApiFileResponse)
+            {
+                return new FileCommandResultWriter();
+            }
+
+            return serializationType switch
+            {
+                SerializationType.MessagePack => new MessagePackCommandResultWriter(),
+
+                _ => new JsonCommandResultWriter()
+            };
+        }
+    }
+}

--- a/src/server/NextApi.Server/Base/FileCommandResultWriter.cs
+++ b/src/server/NextApi.Server/Base/FileCommandResultWriter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using NextApi.Common;
+using NextApi.Server.Service;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Writes <see cref="NextApiFileResponse"/> to <see cref="HttpResponse"/>.
+    /// </summary>
+    internal class FileCommandResultWriter : ICommandResultWriter
+    {
+        /// <inheritdoc/>
+        /// <exception cref="ArgumentException"> Thrown when <paramref name="commandResult"/> is not <see cref="NextApiFileResponse"/></exception>
+        public async Task Write(HttpResponse httpResponse, INextApiResponse commandResult)
+        {
+            if (commandResult is NextApiFileResponse fileResponse)
+            {
+                await httpResponse.SendNextApiFileResponse(fileResponse);
+            }
+
+            throw new ArgumentException($"Result must be of type {typeof(NextApiFileResponse)}", nameof(commandResult));
+        }
+    }
+}

--- a/src/server/NextApi.Server/Base/ICommandArgsExtractor.cs
+++ b/src/server/NextApi.Server/Base/ICommandArgsExtractor.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using NextApi.Common;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Interface is a contract for extracing NextApi command arguments from <see cref="IFormCollection"/>.
+    /// </summary>
+    internal interface ICommandArgsExtractor
+    {
+        /// <summary>
+        /// Extracts NextApi command arguments from form.
+        /// </summary>
+        /// <param name="form"> Http forms collection. </param>
+        /// <returns> Array of NextApi command arguments. </returns>
+        Task<INextApiArgument[]> Extract(IFormCollection form);
+    }
+}

--- a/src/server/NextApi.Server/Base/ICommandResultWriter.cs
+++ b/src/server/NextApi.Server/Base/ICommandResultWriter.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using NextApi.Common;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Interface is contract for writing NextApi responses to <see cref="HttpResponse"/>.
+    /// </summary>
+    internal interface ICommandResultWriter
+    {
+        /// <summary>
+        /// Writes NextApi response to HttpResponse.
+        /// </summary>
+        /// <param name="httpResponse"> Http response </param>
+        /// <param name="commandResult"> NextApi response to write </param>
+        /// <returns></returns>
+        Task Write(HttpResponse httpResponse, INextApiResponse commandResult);
+    }
+}

--- a/src/server/NextApi.Server/Base/JsonCommandArgsExtractor.cs
+++ b/src/server/NextApi.Server/Base/JsonCommandArgsExtractor.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+using NextApi.Common;
+using NextApi.Common.Serialization;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Extracts NextApi command arguments using Json serializer.
+    /// </summary>
+    internal class JsonCommandArgsExtractor : ICommandArgsExtractor
+    {
+        private static readonly Task<INextApiArgument[]> CachedNull = Task.FromResult(null as INextApiArgument[]);
+
+        /// <inheritdoc/>
+        public Task<INextApiArgument[]> Extract(IFormCollection form)
+        {
+            var argsString = form["Args"].FirstOrDefault();
+
+            if (string.IsNullOrEmpty(argsString))
+            {
+                return CachedNull;
+            }
+
+            return Task.FromResult(JsonConvert
+                .DeserializeObject<IEnumerable<NextApiJsonArgument>>(argsString, SerializationUtils.GetJsonConfig())
+                .Cast<INextApiArgument>()
+                .ToArray());
+        }
+    }
+}

--- a/src/server/NextApi.Server/Base/JsonCommandResultWriter.cs
+++ b/src/server/NextApi.Server/Base/JsonCommandResultWriter.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using NextApi.Common;
+using NextApi.Server.Service;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Writes <see cref="INextApiResponse"/> to <see cref="HttpResponse"/> as json.
+    /// </summary>
+    internal class JsonCommandResultWriter : ICommandResultWriter
+    {
+        /// <inheritdoc/>
+        public async Task Write(HttpResponse httpResponse, INextApiResponse commandResult)
+        {
+            await httpResponse.SendJson(commandResult);
+        }
+    }
+}

--- a/src/server/NextApi.Server/Base/MessagePackCommandArgsExtractor.cs
+++ b/src/server/NextApi.Server/Base/MessagePackCommandArgsExtractor.cs
@@ -1,0 +1,25 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using MessagePack;
+using Microsoft.AspNetCore.Http;
+using NextApi.Common;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Extracts NextApi command arguments using MessagePack serializer.
+    /// </summary>
+    internal class MessagePackCommandArgsExtractor : ICommandArgsExtractor
+    {
+        /// <inheritdoc/>
+        public async Task<INextApiArgument[]> Extract(IFormCollection form)
+        {
+            var argsFile = form.Files["Args"];
+
+            using var memoryStream = new MemoryStream();
+            await argsFile.CopyToAsync(memoryStream);
+
+            return MessagePackSerializer.Typeless.Deserialize(memoryStream.ToArray()) as INextApiArgument[];
+        }
+    }
+}

--- a/src/server/NextApi.Server/Base/MessagePackCommandResultWriter.cs
+++ b/src/server/NextApi.Server/Base/MessagePackCommandResultWriter.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using MessagePack;
+using Microsoft.AspNetCore.Http;
+using NextApi.Common;
+using NextApi.Server.Service;
+
+namespace NextApi.Server.Base
+{
+    /// <summary>
+    /// Writes NextApi response to HttpResponse as MessagePack encoded byte array.
+    /// </summary>
+    internal class MessagePackCommandResultWriter : ICommandResultWriter
+    {
+        /// <inheritdoc/>
+        public async Task Write(HttpResponse httpResponse, INextApiResponse commandResult)
+        {
+            await httpResponse.SendByteArray(MessagePackSerializer.Serialize(commandResult));
+        }
+    }
+}


### PR DESCRIPTION
Here is refactoring for NextApi.Server/Base/NextApiHttp.

Extracting command arguments and writing its results into HttpResponse was split into different classes that encapsulates serialization logic.

This update will allow us to easily add new serialization types.